### PR TITLE
The ORM config factory mistake was corrected

### DIFF
--- a/jirm-orm/src/main/java/co/jirm/orm/OrmConfig.java
+++ b/jirm-orm/src/main/java/co/jirm/orm/OrmConfig.java
@@ -33,7 +33,7 @@ public class OrmConfig {
 	}
 	
 	public static OrmConfig newInstance(SqlExecutor sqlExecutor, SqlObjectConfig objectConfig) {
-		return new OrmConfig(sqlExecutor, SqlObjectConfig.DEFAULT, SqlWriterStrategy.newInstance("\n"));
+		return new OrmConfig(sqlExecutor, objectConfig, SqlWriterStrategy.newInstance("\n"));
 	}
 	
 	public static OrmConfig newInstance(SqlExecutor sqlExecutor) {


### PR DESCRIPTION
It seems that the SqlObjectConfig parameter in the ORM config factory was mistakenly ignored.
