### PR TITLE
Management of the last upper-case letter in class names was added.

### DIFF
--- a/jirm-orm/src/main/java/co/jirm/mapper/definition/DefaultNamingStrategy.java
+++ b/jirm-orm/src/main/java/co/jirm/mapper/definition/DefaultNamingStrategy.java
@@ -60,11 +60,11 @@ public class DefaultNamingStrategy implements NamingStrategy, Serializable {
 
 	protected static String addUnderscores(String name) {
 		StringBuilder buf = new StringBuilder( name.replace('.', '_') );
-		for (int i=1; i<buf.length()-1; i++) {
+		for (int i=1; i<buf.length(); i++) {
 			if (
 				Character.isLowerCase( buf.charAt(i-1) ) &&
 				Character.isUpperCase( buf.charAt(i) ) &&
-				Character.isLowerCase( buf.charAt(i+1) )
+				(i >= buf.length() - 1 || Character.isLowerCase( buf.charAt(i+1)) )
 			) {
 				buf.insert(i++, '_');
 			}


### PR DESCRIPTION
Classes with names like `ClassNameA` were made to be translated to `class_name_a` for the SQL representation.
