### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
           <excludes>
             <exclude>**/*BenchTest.java</exclude>
           </excludes>
+						<disableXmlReport>${closeTestReports}</disableXmlReport>
         </configuration>
       </plugin>
 
@@ -263,6 +264,7 @@
 							<database.url>jdbc:postgresql://127.0.0.1:5432/myapp_test</database.url>
 							<database.password />
 						</systemPropertyVariables>
+						<disableXmlReport>${closeTestReports}</disableXmlReport>
 					</configuration>
 				</plugin>
 			</plugins>
@@ -279,5 +281,6 @@
     <!-- Encoding UTF-8 -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jackson2-version>2.0.5</jackson2-version>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 </project>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
